### PR TITLE
Remove Ghostlines

### DIFF
--- a/_data/ghostlines.yml
+++ b/_data/ghostlines.yml
@@ -1,8 +1,0 @@
-description: Integrate feedback from friends and peers into your drawing process
-developer: Ghostlines
-developerURL: http://ghostlines.pm
-extensionName: Ghostlines
-extensionPath: Ghostlines.roboFontExt
-repository: https://github.com/ghostlines/ghostlines-robofont
-tags: [workflow]
-dateAdded: 2017-03-07 16:04:27


### PR DESCRIPTION
This service is no longer online, so the extension should simply be removed.