### PR TITLE
Booster, Paste Glyph and ToolManager have their info.plist inside the build/ directory

### DIFF
--- a/_data/booster.yml
+++ b/_data/booster.yml
@@ -2,7 +2,7 @@ description: A framework used by other extensions to enhance their functionality
 developer: Tal Leming
 developerURL: https://github.com/typesupply
 extensionName: Booster
-extensionPath: Booster.roboFontExt
+extensionPath: build/Booster.roboFontExt
 repository: https://github.com/typesupply/booster
 tags: [scripting, framework]
 dateAdded: 2019-04-17 09:15:00

--- a/_data/pasteGlyph.yml
+++ b/_data/pasteGlyph.yml
@@ -2,7 +2,7 @@ description: Interface for quickly pasting a glyph into the one you are currentl
 developer: Tal Leming
 developerURL: https://github.com/typesupply
 extensionName: Paste Glyph
-extensionPath: Paste Glyph.roboFontExt
+extensionPath: build/Paste Glyph.roboFontExt
 repository: https://github.com/typesupply/pasteglyph
 tags: [design helpers, drawing]
 dateAdded: 2019-04-17 09:15:00

--- a/_data/toolManager.yml
+++ b/_data/toolManager.yml
@@ -2,7 +2,7 @@ description: UI hack, that helps you manage or get rid of default toolbar.
 developer: Rafał Buchner
 developerURL: http://www.rafalbuchner.com
 extensionName: ToolManager
-extensionPath: 'ToolManager.roboFontExt'
+extensionPath: 'build/ToolManager.roboFontExt'
 repository: https://github.com/RafalBuchner/tool-manager
 tags: [toolbar tools]
 dateAdded: 2019-07-22 17:39:52


### PR DESCRIPTION
I saw some spew in `~/Library/Application\ Support/RoboFont/robofont-3-py3.log`, wrote a script to check all the repository URLs of the `_data/*.yml` files, found these three and verified they all put the `.roboFontExt` file inside their `build/` directory.