### PR TITLE
removing fontToolsDocs and measureHandles, updating groupSpacing

### DIFF
--- a/_data/fontToolsDocs.yml
+++ b/_data/fontToolsDocs.yml
@@ -1,8 +1,0 @@
-description: The FontTools documentation as a RoboFont extension.
-developer: FontTools Developers
-developerURL: http://github.com/fonttools/fonttools
-extensionName: FontTools Docs
-extensionPath: fontToolsDocs.roboFontExt
-icon: http://github.com/roboDocs/fontToolsDocs/raw/master/fontToolsDocsMechanicIcon.png
-repository: http://github.com/roboDocs/fontToolsDocs
-tags: [documentation, scripting, mastering, TrueType, OpenType features]

--- a/_data/groupSpacing.yml
+++ b/_data/groupSpacing.yml
@@ -1,8 +1,8 @@
 description: Enable group spacing in the Space Center.
 developer: Gustavo Ferreira
 developerURL: http://github.com/gferreira
-extensionName: groupSpacing
+extensionName: Group Spacing
 extensionPath: groupSpacing.roboFontExt
 repository: http://github.com/gferreira/groupSpacing
-tags: [spacing]
+tags: [spacing, kerning]
 dateAdded: 2019-02-14 12:00:00

--- a/_data/measureHandles.yml
+++ b/_data/measureHandles.yml
@@ -1,8 +1,0 @@
-description: A tool to show the length and angle of handles.
-developer: Gustavo Ferreira
-developerURL: http://hipertipo.com
-extensionName: Measure Handles Tool
-extensionPath: MeasureHandles.roboFontExt
-repository: https://github.com/johannesbreyer/HandleLength
-tags: [design helpers]
-dateAdded: 2016-02-11 17:49:50


### PR DESCRIPTION
- FontTools docs is now [available on ReadTheDocs](http://fonttools.readthedocs.io/)
- [MeasureHandles extension](https://github.com/johannesbreyer/HandleLength) is no longer mantained (a similar tool is [available in hTools3](https://hipertipo.gitlab.io/htools3_core_extension/glyph/measurements/))
- changing extension name from `groupSpacing` to `Group Spacing`