### PR TITLE
Deprecation Notice for Random Word Generator

### DIFF
--- a/_data/randomWordGenerator.yml
+++ b/_data/randomWordGenerator.yml
@@ -1,7 +1,7 @@
-description: Generate random words to proof fonts in Space Center.
+description: (Superseded by word-o-mat) Generate random words to proof fonts in Space Center.
 developer: David Jonathan Ross
 developerURL: http://www.fontbureau.com
-extensionName: Random Word Generator
+extensionName: Random Word Generator (DEPRECATED)
 extensionPath: 'Retired_Extensions/RandomWordGenerator/Random Word Generator.roboFontExt'
 repository: https://github.com/FontBureau/fbOpenTools
 tags: [proofing, spacing, text]


### PR DESCRIPTION
I installed [Random Word Generator](https://github.com/FontBureau/fbOpenTools/tree/master/Retired_Extensions/RandomWordGenerator), not knowing about [word-o-mat](https://github.com/ninastoessinger/word-o-mat) until I saw the deprecation notice in the README.md of **Random Word Generator**.

I figured some deprecation notice would point newcomers towards the latest, greatest plugin. I didn't see any precedent for this, but I thought the uppercase `DEPRECATED` would do. Does this work for you @djrrb?

Maybe in the future there could be something with formal deprecation and redirection like this issue describes:
https://github.com/Microsoft/vscode/issues/4772