### PR TITLE
Remove RedArrow

### DIFF
--- a/_data/redArrow.yml
+++ b/_data/redArrow.yml
@@ -1,8 +1,0 @@
-description: Mark technical outline errors in your glyphs.
-developer: Jens Kutilek
-developerURL: http://www.kutilek.de
-extensionName: Red Arrow
-extensionPath: RedArrow.roboFontExt
-repository: https://github.com/jenskutilek/RedArrow
-tags: [contours, revisions]
-dateAdded: 2016-02-11 17:49:43


### PR DESCRIPTION
I've discontinued RedArrow.

I've never found the time to update it properly for RoboFont 3/4, and interest in it seems low. There are better alternatives available, like Glyph Nanny.